### PR TITLE
create_event_type method fix

### DIFF
--- a/pyNakadi/client.py
+++ b/pyNakadi/client.py
@@ -208,7 +208,7 @@ class NakadiClient:
         response = requests.post(page, headers=headers,
                                  json=event_type_data_map)
         response_content_str = response.content.decode('utf-8')
-        if response.status_code not in [200, 201]:
+        if response.status_code not in [201]:
             raise NakadiException(
                 code=response.status_code,
                 msg="Error during create_event_type. "

--- a/pyNakadi/client.py
+++ b/pyNakadi/client.py
@@ -208,7 +208,7 @@ class NakadiClient:
         response = requests.post(page, headers=headers,
                                  json=event_type_data_map)
         response_content_str = response.content.decode('utf-8')
-        if response.status_code not in [200]:
+        if response.status_code not in [200, 201]:
             raise NakadiException(
                 code=response.status_code,
                 msg="Error during create_event_type. "


### PR DESCRIPTION
- After successful creation of `event_type` nakadi returns `201`, but in `client.create_event_type` method comparing `200`
- This causes `NakadiException[201]: Error during create_event_type. Message from server:201` even after succussful creation of `event_type`
