### PR TITLE
Make PyNakadi installable without readme_renderer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup
-from readme_renderer import markdown
+try:
+    from readme_renderer import markdown
+except ImportError:
+    markdown = None
 
 
 def readme():
@@ -15,7 +18,7 @@ def get_version():
 setup(name='pyNakadi',
       version=get_version(),
       description='Python client for Nakadi',
-      long_description=markdown.render(readme()),
+      long_description=markdown.render(readme()) if markdown else readme(),
       long_description_content_type="text/markdown",
       classifiers=[
           'Development Status :: 3 - Alpha',


### PR DESCRIPTION
PyNakadi 0.2.14 fails to install with an import error if readme_renderer is not installed:

```
Collecting pynakadi==0.2.14
  Downloading pyNakadi-0.2.14.tar.gz (5.0 kB)
    ERROR: Command errored out with exit status 1:
     command: /home/jsantos/scm/github.bus.zalan.do/automata/approved_base_image_prototype/.venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-f1dkktkx/pynakadi/setup.py'"'"'; __file__='"'"'/tmp/pip-install-f1dkktkx/pynakadi/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-9rdpu4eo
         cwd: /tmp/pip-install-f1dkktkx/pynakadi/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-f1dkktkx/pynakadi/setup.py", line 2, in <module>
        from readme_renderer import markdown
    ModuleNotFoundError: No module named 'readme_renderer'
```

This change implements a fallback to allow installation.