### PR TITLE
Make TLS certificate verification configurable

### DIFF
--- a/pyNakadi/client.py
+++ b/pyNakadi/client.py
@@ -137,7 +137,7 @@ class NakadiStream():
 
 
 class NakadiClient:
-    def __init__(self, token, nakadi_url):
+    def __init__(self, token, nakadi_url, verify_tls_certificate=True):
         """
         Initiates a Nakadi client using the token and aiming for url
         :param token: token string to be used
@@ -145,14 +145,15 @@ class NakadiClient:
         """
         self.token = token
         self.nakadi_url = nakadi_url
-        self.session = self.__create_session(token)
+        self.session = self.__create_session(token, verify_tls_certificate)
 
-    def __create_session(self, token):
+    def __create_session(self, token, verify_tls_certificate):
         result = requests.Session()
         result.headers.update({
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json"
         })
+        result.verify = verify_tls_certificate
         return result
 
     @classmethod


### PR DESCRIPTION
Allow to configure TLS certificate verification upon `NakadiClient` initialization:
* `verify_tls_certificate` parameter is optional and defaults to `True`, so this update will not require any changes from the library clients
* This parameter is applied to `session` meaning certificate verification will be enabled/disabled for _all_ requests

Learn more about [SSL Cert Verification](https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) in the Requests library docs.